### PR TITLE
Add Nix support

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+let 
+  pkgs = import <nixpkgs> { };
+in 
+  pkgs.haskellPackages.developPackage {
+    root = ./.;
+    modifier = drv:
+      pkgs.haskell.lib.addBuildTools drv (with pkgs.haskellPackages;
+        [ cabal-install
+          ghcid
+        ]);
+  }


### PR DESCRIPTION
This allows you to build the project with `nix-build`, as well as drop into a dev shell via `nix-shell`.

More on Nix: https://www.srid.ca/1948201.html